### PR TITLE
fix: use uint64 for interface statistics counters

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2236,49 +2236,49 @@ definitions:
             bytes_received:
                 description: Number of bytes received
                 example: 192021
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: BytesReceived
             bytes_sent:
                 description: Number of bytes sent
                 example: 10888579
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: BytesSent
             errors_received:
                 description: Number of errors received
                 example: 14
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: ErrorsReceived
             errors_sent:
                 description: Number of errors sent
                 example: 41
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: ErrorsSent
             packets_dropped_inbound:
                 description: Number of inbound packets dropped
                 example: 179
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsDroppedInbound
             packets_dropped_outbound:
                 description: Number of outbound packets dropped
                 example: 541
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsDroppedOutbound
             packets_received:
                 description: Number of packets received
                 example: 1748
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsReceived
             packets_sent:
                 description: Number of packets sent
                 example: 964
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsSent
         type: object
@@ -3263,25 +3263,25 @@ definitions:
             bytes_received:
                 description: Number of bytes received
                 example: 250542118
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: BytesReceived
             bytes_sent:
                 description: Number of bytes sent
                 example: 17524040140
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: BytesSent
             packets_received:
                 description: Number of packets received
                 example: 1182515
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsReceived
             packets_sent:
                 description: Number of packets sent
                 example: 1567934
-                format: int64
+                format: uint64
                 type: integer
                 x-go-name: PacketsSent
         type: object

--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -379,14 +379,14 @@ func getNetworkMetrics(d *Daemon) (map[string]metrics.NetworkMetrics, error) {
 	for dev, state := range networkState() {
 		stats := metrics.NetworkMetrics{}
 
-		stats.ReceiveBytes = uint64(state.Counters.BytesReceived)
-		stats.ReceiveDrop = uint64(state.Counters.PacketsDroppedInbound)
-		stats.ReceiveErrors = uint64(state.Counters.ErrorsReceived)
-		stats.ReceivePackets = uint64(state.Counters.PacketsReceived)
-		stats.TransmitBytes = uint64(state.Counters.BytesSent)
-		stats.TransmitDrop = uint64(state.Counters.PacketsDroppedOutbound)
-		stats.TransmitErrors = uint64(state.Counters.ErrorsSent)
-		stats.TransmitPackets = uint64(state.Counters.PacketsSent)
+		stats.ReceiveBytes = state.Counters.BytesReceived
+		stats.ReceiveDrop = state.Counters.PacketsDroppedInbound
+		stats.ReceiveErrors = state.Counters.ErrorsReceived
+		stats.ReceivePackets = state.Counters.PacketsReceived
+		stats.TransmitBytes = state.Counters.BytesSent
+		stats.TransmitDrop = state.Counters.PacketsDroppedOutbound
+		stats.TransmitErrors = state.Counters.ErrorsSent
+		stats.TransmitPackets = state.Counters.PacketsSent
 
 		out[dev] = stats
 	}

--- a/lxd-agent/state.go
+++ b/lxd-agent/state.go
@@ -150,26 +150,26 @@ func networkState() map[string]api.InstanceStateNetwork {
 		}
 
 		// Counters
-		value, err := os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_bytes", iface.Name))
-		valueInt, err1 := strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
+		value, err := os.ReadFile("/sys/class/net/" + iface.Name + "/statistics/tx_bytes")
+		valueInt, err1 := strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.BytesSent = valueInt
 		}
 
-		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_bytes", iface.Name))
-		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
+		value, err = os.ReadFile("/sys/class/net/" + iface.Name + "/statistics/rx_bytes")
+		valueInt, err1 = strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.BytesReceived = valueInt
 		}
 
-		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/tx_packets", iface.Name))
-		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
+		value, err = os.ReadFile("/sys/class/net/" + iface.Name + "/statistics/tx_packets")
+		valueInt, err1 = strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.PacketsSent = valueInt
 		}
 
-		value, err = os.ReadFile(fmt.Sprintf("/sys/class/net/%s/statistics/rx_packets", iface.Name))
-		valueInt, err1 = strconv.ParseInt(strings.TrimSpace(string(value)), 10, 64)
+		value, err = os.ReadFile("/sys/class/net/" + iface.Name + "/statistics/rx_packets")
+		valueInt, err1 = strconv.ParseUint(strings.TrimSpace(string(value)), 10, 64)
 		if err == nil && err1 == nil {
 			network.Counters.PacketsReceived = valueInt
 		}

--- a/lxd/instance/drivers/driver_qemu_metrics.go
+++ b/lxd/instance/drivers/driver_qemu_metrics.go
@@ -54,14 +54,14 @@ func (d *qemu) getQemuMetrics() (*metrics.MetricSet, error) {
 
 		for name, state := range networkState {
 			out.Network[name] = metrics.NetworkMetrics{
-				ReceiveBytes:    uint64(state.Counters.BytesReceived),
-				ReceiveDrop:     uint64(state.Counters.PacketsDroppedInbound),
-				ReceiveErrors:   uint64(state.Counters.ErrorsReceived),
-				ReceivePackets:  uint64(state.Counters.PacketsReceived),
-				TransmitBytes:   uint64(state.Counters.BytesSent),
-				TransmitDrop:    uint64(state.Counters.PacketsDroppedOutbound),
-				TransmitErrors:  uint64(state.Counters.ErrorsSent),
-				TransmitPackets: uint64(state.Counters.PacketsSent),
+				ReceiveBytes:    state.Counters.BytesReceived,
+				ReceiveDrop:     state.Counters.PacketsDroppedInbound,
+				ReceiveErrors:   state.Counters.ErrorsReceived,
+				ReceivePackets:  state.Counters.PacketsReceived,
+				TransmitBytes:   state.Counters.BytesSent,
+				TransmitDrop:    state.Counters.PacketsDroppedOutbound,
+				TransmitErrors:  state.Counters.ErrorsSent,
+				TransmitPackets: state.Counters.PacketsSent,
 			}
 		}
 	}

--- a/lxd/resources/network.go
+++ b/lxd/resources/network.go
@@ -801,22 +801,22 @@ func GetNetworkCounters(name string) (*api.NetworkStateCounters, error) {
 			continue
 		}
 
-		rxBytes, err := strconv.ParseInt(fields[1], 10, 64)
+		rxBytes, err := strconv.ParseUint(fields[1], 10, 64)
 		if err != nil {
 			return nil, err
 		}
 
-		rxPackets, err := strconv.ParseInt(fields[2], 10, 64)
+		rxPackets, err := strconv.ParseUint(fields[2], 10, 64)
 		if err != nil {
 			return nil, err
 		}
 
-		txBytes, err := strconv.ParseInt(fields[9], 10, 64)
+		txBytes, err := strconv.ParseUint(fields[9], 10, 64)
 		if err != nil {
 			return nil, err
 		}
 
-		txPackets, err := strconv.ParseInt(fields[10], 10, 64)
+		txPackets, err := strconv.ParseUint(fields[10], 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -181,33 +181,33 @@ type InstanceStateNetworkAddress struct {
 type InstanceStateNetworkCounters struct {
 	// Number of bytes received
 	// Example: 192021
-	BytesReceived int64 `json:"bytes_received" yaml:"bytes_received"`
+	BytesReceived uint64 `json:"bytes_received" yaml:"bytes_received"`
 
 	// Number of bytes sent
 	// Example: 10888579
-	BytesSent int64 `json:"bytes_sent" yaml:"bytes_sent"`
+	BytesSent uint64 `json:"bytes_sent" yaml:"bytes_sent"`
 
 	// Number of packets received
 	// Example: 1748
-	PacketsReceived int64 `json:"packets_received" yaml:"packets_received"`
+	PacketsReceived uint64 `json:"packets_received" yaml:"packets_received"`
 
 	// Number of packets sent
 	// Example: 964
-	PacketsSent int64 `json:"packets_sent" yaml:"packets_sent"`
+	PacketsSent uint64 `json:"packets_sent" yaml:"packets_sent"`
 
 	// Number of errors received
 	// Example: 14
-	ErrorsReceived int64 `json:"errors_received" yaml:"errors_received"`
+	ErrorsReceived uint64 `json:"errors_received" yaml:"errors_received"`
 
 	// Number of errors sent
 	// Example: 41
-	ErrorsSent int64 `json:"errors_sent" yaml:"errors_sent"`
+	ErrorsSent uint64 `json:"errors_sent" yaml:"errors_sent"`
 
 	// Number of outbound packets dropped
 	// Example: 541
-	PacketsDroppedOutbound int64 `json:"packets_dropped_outbound" yaml:"packets_dropped_outbound"`
+	PacketsDroppedOutbound uint64 `json:"packets_dropped_outbound" yaml:"packets_dropped_outbound"`
 
 	// Number of inbound packets dropped
 	// Example: 179
-	PacketsDroppedInbound int64 `json:"packets_dropped_inbound" yaml:"packets_dropped_inbound"`
+	PacketsDroppedInbound uint64 `json:"packets_dropped_inbound" yaml:"packets_dropped_inbound"`
 }

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -211,19 +211,19 @@ type NetworkStateAddress struct {
 type NetworkStateCounters struct {
 	// Number of bytes received
 	// Example: 250542118
-	BytesReceived int64 `json:"bytes_received" yaml:"bytes_received"`
+	BytesReceived uint64 `json:"bytes_received" yaml:"bytes_received"`
 
 	// Number of bytes sent
 	// Example: 17524040140
-	BytesSent int64 `json:"bytes_sent" yaml:"bytes_sent"`
+	BytesSent uint64 `json:"bytes_sent" yaml:"bytes_sent"`
 
 	// Number of packets received
 	// Example: 1182515
-	PacketsReceived int64 `json:"packets_received" yaml:"packets_received"`
+	PacketsReceived uint64 `json:"packets_received" yaml:"packets_received"`
 
 	// Number of packets sent
 	// Example: 1567934
-	PacketsSent int64 `json:"packets_sent" yaml:"packets_sent"`
+	PacketsSent uint64 `json:"packets_sent" yaml:"packets_sent"`
 }
 
 // NetworkStateBond represents bond specific state

--- a/shared/netutils/network_linux_cgo.go
+++ b/shared/netutils/network_linux_cgo.go
@@ -201,14 +201,14 @@ func NetnsGetifaddrs(initPID int32, hostInterfaces []net.Interface) (map[string]
 		}
 
 		if addr.ifa_stats_type == C.IFLA_STATS64 {
-			addNetwork.Counters.BytesReceived = int64(addr.ifa_stats64.rx_bytes)
-			addNetwork.Counters.BytesSent = int64(addr.ifa_stats64.tx_bytes)
-			addNetwork.Counters.PacketsReceived = int64(addr.ifa_stats64.rx_packets)
-			addNetwork.Counters.PacketsSent = int64(addr.ifa_stats64.tx_packets)
-			addNetwork.Counters.ErrorsReceived = int64(addr.ifa_stats64.rx_errors)
-			addNetwork.Counters.ErrorsSent = int64(addr.ifa_stats64.tx_errors)
-			addNetwork.Counters.PacketsDroppedInbound = int64(addr.ifa_stats64.rx_dropped)
-			addNetwork.Counters.PacketsDroppedOutbound = int64(addr.ifa_stats64.tx_dropped)
+			addNetwork.Counters.BytesReceived = uint64(addr.ifa_stats64.rx_bytes)
+			addNetwork.Counters.BytesSent = uint64(addr.ifa_stats64.tx_bytes)
+			addNetwork.Counters.PacketsReceived = uint64(addr.ifa_stats64.rx_packets)
+			addNetwork.Counters.PacketsSent = uint64(addr.ifa_stats64.tx_packets)
+			addNetwork.Counters.ErrorsReceived = uint64(addr.ifa_stats64.rx_errors)
+			addNetwork.Counters.ErrorsSent = uint64(addr.ifa_stats64.tx_errors)
+			addNetwork.Counters.PacketsDroppedInbound = uint64(addr.ifa_stats64.rx_dropped)
+			addNetwork.Counters.PacketsDroppedOutbound = uint64(addr.ifa_stats64.tx_dropped)
 		}
 
 		ifName := C.GoString(addr.ifa_name)

--- a/shared/units/units.go
+++ b/shared/units/units.go
@@ -155,9 +155,13 @@ func ParseBitSizeString(input string) (int64, error) {
 	return handleOverflow(valueInt, multiplicator)
 }
 
+type integer interface {
+	~int64 | ~uint64
+}
+
 // GetByteSizeString takes a number of bytes and precision and returns a
 // human representation of the amount of data.
-func GetByteSizeString(input int64, precision uint) string {
+func GetByteSizeString[T integer](input T, precision uint) string {
 	if input < 1000 {
 		return fmt.Sprintf("%dB", input)
 	}
@@ -176,7 +180,7 @@ func GetByteSizeString(input int64, precision uint) string {
 
 // GetByteSizeStringIEC takes a number of bytes and precision and returns a
 // human representation of the amount of data using IEC units.
-func GetByteSizeStringIEC(input int64, precision uint) string {
+func GetByteSizeStringIEC[T integer](input T, precision uint) string {
 	if input < 1024 {
 		return fmt.Sprintf("%dB", input)
 	}


### PR DESCRIPTION
The /proc/net/dev as well as /sys/class/net/{iface}/statistics uses struct
rtnl_link_stats64, where all counters are __u64.

Previously, parsing these values into int64 caused errors for large counters:

    strconv.ParseInt: parsing "18446744073709551613": value out of range

This commit ensures that all counters are treated as uint64.

See: https://www.kernel.org/doc/html/latest/networking/statistics.html